### PR TITLE
Modules in api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 /.serverless
 
 # Dependencies
-/node_modules
+node_modules
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /.serverless
 
 # Dependencies
-/node_modules
+node_modules
 
 # Logs
 logs

--- a/api/server/schema.ts
+++ b/api/server/schema.ts
@@ -8,10 +8,7 @@ export const schema = makeSchema({
   shouldGenerateArtifacts: config.isOffline,
   outputs: {
     schema: join(__dirname, "../api.graphql"),
-    typegen: join(
-      __dirname,
-      "../../node_modules/@types/nexus-typegen/index.d.ts"
-    ),
+    typegen: join(__dirname, "../node_modules/@types/nexus-typegen/index.d.ts"),
   },
   plugins: [
     nexusPrisma({
@@ -21,7 +18,7 @@ export const schema = makeSchema({
       outputs: {
         typegen: join(
           __dirname,
-          "../../node_modules/@types/typegen-nexus-plugin-prisma/index.d.ts"
+          "../node_modules/@types/typegen-nexus-plugin-prisma/index.d.ts"
         ),
       },
     }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "typeRoots": ["node_modules/@types"]
+    "typeRoots": ["node_modules/@types", "api/node_modules/@types"]
   }
 }


### PR DESCRIPTION
Host generated node_modules types in api/, so they don't get blasted whenever new packages are installed.